### PR TITLE
Fix quilt.mod.json contributors being wrong type (expected Object, provided Array)

### DIFF
--- a/src/templates/quilt/src/main/resources/quilt.mod.json
+++ b/src/templates/quilt/src/main/resources/quilt.mod.json
@@ -7,9 +7,9 @@
     "metadata": {
       "name": "%MOD_NAME%",
       "description": "This is an example description! Tell everyone what your mod is about!",
-      "contributors": [
-        "Me!"
-      ],
+      "contributors": {
+        "Me!": "Author"
+      },
       "icon": "assets/%MOD_ID%/icon.png"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",


### PR DESCRIPTION
When running a template project with Quilt, it crashes because the "contributors" field's type is incorrect.