### PR TITLE
Validate that at least one loader is checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A generator for Architectury mod templates with a web UI and an interactive comm
 
 Run `./gradlew buildWeb`. The output will be in `build/web`.
 
-The local test web server can be launched with `./gradlew runTestServer` (requires Python).
+The local test web server can be launched with `./gradlew runTestServer` (requires Python). While running, this web server can be viewed at http://localhost:8000.
 
 ## Building (native)
 

--- a/res/script.js
+++ b/res/script.js
@@ -174,6 +174,10 @@ function refreshFabricLikeCheckbox() {
     fabricLikeInput.disabled = !hasFabricLike;
 }
 
+function isLoaderChecked() {
+    return document.getElementById("fabric-loader-input").checked || document.getElementById("forge-loader-input").checked || document.getElementById("neoforge-loader-input").checked || document.getElementById("quilt-loader-input").checked
+}
+
 document.getElementById("generate-button").onclick = async () => {
     updateState();
 
@@ -186,6 +190,9 @@ document.getElementById("generate-button").onclick = async () => {
     } else if (state.package_name === "") {
         showError("Package name is empty");
         return;
+    } else if (!isLoaderChecked()) {
+        showError("You need to choose at least one loader first!")
+        return
     }
 
     clearError();

--- a/res/script.js
+++ b/res/script.js
@@ -191,7 +191,7 @@ document.getElementById("generate-button").onclick = async () => {
         showError("Package name is empty");
         return;
     } else if (!isLoaderChecked()) {
-        showError("You need to choose at least one loader first!")
+        showError("You need to choose at least one subproject first!")
         return
     }
 

--- a/src/app/versions.rs
+++ b/src/app/versions.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-pub const LOOM_VERSION: &'static str = "1.6-SNAPSHOT";
+pub const LOOM_VERSION: &'static str = "1.7-SNAPSHOT";
 pub const PLUGIN_VERSION: &'static str = "3.4-SNAPSHOT";
 
 use miette::Result;

--- a/version_resolver/src/minecraft.rs
+++ b/version_resolver/src/minecraft.rs
@@ -43,6 +43,8 @@ pub enum MinecraftVersion {
     Minecraft1_21_2,
     #[serde(rename = "1.21.3")]
     Minecraft1_21_3,
+    #[serde(rename = "1.21.4")]
+    Minecraft1_21_4,
 }
 
 impl MinecraftVersion {
@@ -71,6 +73,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => "1.21.1",
             Self::Minecraft1_21_2 => "1.21.2",
             Self::Minecraft1_21_3 => "1.21.3",
+            Self::Minecraft1_21_4 => "1.21.4",
         }
     }
 
@@ -139,6 +142,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => None,
             Self::Minecraft1_21_2 => None,
             Self::Minecraft1_21_3 => None,
+            Self::Minecraft1_21_4 => None,
         }
     }
 
@@ -162,6 +166,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => "13",
             Self::Minecraft1_21_2 => "14",
             Self::Minecraft1_21_3 => "14",
+            Self::Minecraft1_21_4 => "15",
 
         }
     }
@@ -175,6 +180,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => Some("4"),
             Self::Minecraft1_21_2 => Some("4"),
             Self::Minecraft1_21_3 => Some("4"),
+            Self::Minecraft1_21_4 => Some("4"),
             _ => None,
         }
     }
@@ -188,6 +194,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => Some("21.1"),
             Self::Minecraft1_21_2 => Some("21.2"),
             Self::Minecraft1_21_3 => Some("21.3"),
+            Self::Minecraft1_21_4 => Some("21.4"),
             _ => None,
         }
     }
@@ -200,6 +207,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => Some("1.21"),
             Self::Minecraft1_21_2 => Some("1.21"),
             Self::Minecraft1_21_3 => Some("1.21"),
+            Self::Minecraft1_21_4 => Some("1.21"),
             _ => None,
         }
     }
@@ -224,6 +232,7 @@ impl MinecraftVersion {
             Self::Minecraft1_21_1 => None,
             Self::Minecraft1_21_2 => None,
             Self::Minecraft1_21_3 => None,
+            Self::Minecraft1_21_4 => None,
         }
     }
 

--- a/version_resolver/src/minecraft.rs
+++ b/version_resolver/src/minecraft.rs
@@ -37,6 +37,12 @@ pub enum MinecraftVersion {
     Minecraft1_20_6,
     #[serde(rename = "1.21")]
     Minecraft1_21,
+    #[serde(rename = "1.21.1")]
+    Minecraft1_21_1,
+    #[serde(rename = "1.21.2")]
+    Minecraft1_21_2,
+    #[serde(rename = "1.21.3")]
+    Minecraft1_21_3,
 }
 
 impl MinecraftVersion {
@@ -62,6 +68,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => "1.20.5",
             Self::Minecraft1_20_6 => "1.20.6",
             Self::Minecraft1_21 => "1.21",
+            Self::Minecraft1_21_1 => "1.21.1",
+            Self::Minecraft1_21_2 => "1.21.2",
+            Self::Minecraft1_21_3 => "1.21.3",
         }
     }
 
@@ -127,6 +136,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => None,
             Self::Minecraft1_20_6 => None,
             Self::Minecraft1_21 => None,
+            Self::Minecraft1_21_1 => None,
+            Self::Minecraft1_21_2 => None,
+            Self::Minecraft1_21_3 => None,
         }
     }
 
@@ -147,6 +159,10 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => "12.0",
             Self::Minecraft1_20_6 => "12",
             Self::Minecraft1_21 => "13",
+            Self::Minecraft1_21_1 => "13",
+            Self::Minecraft1_21_2 => "14",
+            Self::Minecraft1_21_3 => "14",
+
         }
     }
 
@@ -156,6 +172,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => Some("2"),
             Self::Minecraft1_20_6 => Some("2"),
             Self::Minecraft1_21 => Some("4"),
+            Self::Minecraft1_21_1 => Some("4"),
+            Self::Minecraft1_21_2 => Some("4"),
+            Self::Minecraft1_21_3 => Some("4"),
             _ => None,
         }
     }
@@ -166,6 +185,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => Some("20.5"),
             Self::Minecraft1_20_6 => Some("20.6"),
             Self::Minecraft1_21 => Some("21.0"),
+            Self::Minecraft1_21_1 => Some("21.1"),
+            Self::Minecraft1_21_2 => Some("21.2"),
+            Self::Minecraft1_21_3 => Some("21.3"),
             _ => None,
         }
     }
@@ -175,6 +197,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => Some("1.20.5"),
             Self::Minecraft1_20_6 => Some("1.20.6"),
             Self::Minecraft1_21 => Some("1.21"),
+            Self::Minecraft1_21_1 => Some("1.21"),
+            Self::Minecraft1_21_2 => Some("1.21"),
+            Self::Minecraft1_21_3 => Some("1.21"),
             _ => None,
         }
     }
@@ -196,6 +221,9 @@ impl MinecraftVersion {
             Self::Minecraft1_20_5 => None,
             Self::Minecraft1_20_6 => None,
             Self::Minecraft1_21 => None,
+            Self::Minecraft1_21_1 => None,
+            Self::Minecraft1_21_2 => None,
+            Self::Minecraft1_21_3 => None,
         }
     }
 


### PR DESCRIPTION
Dependent on #23. I've seen multiple accounts of people using this generator and not realizing they need to check the boxes for the loaders they want to build for, so this PR adds in a simple check to see if any of the boxes are ticked.

Without selecting any loaders, Architectury will fail to build anyway - see https://github.com/architectury/architectury-api/issues/582 and in [Discord](https://discord.com/channels/792699517631594506/1299148417586692147/1299148417586692147).