### PR TITLE
Disable Architectury API where a Forge port does not exist

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -38,7 +38,7 @@ for (const input of projectTypeToggles) {
 
 // Add listeners to Forge checkboxes for controlling the Architectury API checkbox.
 document.getElementById("forge-loader-input").onchange = refreshArchitecturySupport;
-refreshArchitecturySupport()
+refreshArchitecturySupport();
 
 // Add listeners to Fabric and Quilt checkboxes for controlling the Fabric-like checkbox,
 // and refresh the Fabric-like status according to the default state.
@@ -166,7 +166,7 @@ function isArchitecturyApiAvailable() {
 function refreshAvailablePlatforms() {
     refreshForgeLikePlatform(isNeoForgeAvailable(), "neoforge");
     refreshForgeLikePlatform(isForgeAvailable(), "forge");
-    refreshArchitecturySupport()
+    refreshArchitecturySupport();
 }
 
 function refreshForgeLikePlatform(available, id) {
@@ -185,12 +185,11 @@ function refreshForgeLikePlatform(available, id) {
 
 function refreshArchitecturySupport() {
     if (!isArchitecturyApiAvailable()) {
-        document.getElementById("architectury-api-input").disabled = true
+        document.getElementById("architectury-api-input").disabled = true;
+    } else {
+        document.getElementById("architectury-api-input").disabled = false;
     }
-    else {
-        document.getElementById("architectury-api-input").disabled = false
-    }
-}
+};
 
 // Enables/disables the Fabric-like checkbox based on whether it can be selected for the current state.
 function refreshFabricLikeCheckbox() {

--- a/res/script.js
+++ b/res/script.js
@@ -156,9 +156,8 @@ function isForgeAvailable() {
 function isArchitecturyApiAvailable() {
     const version = mcSelect.value;
     if (document.getElementById("forge-loader-input").checked) {
-        return arch_api_supports_forge(version)
-    }
-    else {
+        return arch_api_supports_forge(version);
+    } else {
         return true;
     }
 }

--- a/res/script.js
+++ b/res/script.js
@@ -184,7 +184,6 @@ function refreshForgeLikePlatform(available, id) {
 }
 
 function refreshArchitecturySupport() {
-    console.log(isArchitecturyApiAvailable())
     if (!isArchitecturyApiAvailable()) {
         document.getElementById("architectury-api-input").disabled = true
     }

--- a/res/script.js
+++ b/res/script.js
@@ -9,6 +9,7 @@ import init, {
     list_all_minecraft_versions,
     supports_forge,
     supports_neoforge,
+    arch_api_supports_forge,
     to_mod_id,
     validate_mod_id
 } from "./templateer.js";
@@ -34,6 +35,10 @@ const multiplatformSettings = document.getElementById("multiplatform-settings");
 for (const input of projectTypeToggles) {
     input.onchange = refreshDisplayedProjectType;
 };
+
+// Add listeners to Forge checkboxes for controlling the Architectury API checkbox.
+document.getElementById("forge-loader-input").onchange = refreshArchitecturySupport;
+refreshArchitecturySupport()
 
 // Add listeners to Fabric and Quilt checkboxes for controlling the Fabric-like checkbox,
 // and refresh the Fabric-like status according to the default state.
@@ -109,7 +114,7 @@ function updateState() {
     state.subprojects.neoforge = document.getElementById("neoforge-loader-input").checked && isNeoForgeAvailable();
     state.subprojects.quilt = document.getElementById("quilt-loader-input").checked;
     state.subprojects.fabric_likes = document.getElementById("fabric-like-input").checked && isFabricLikeAvailable();
-    state.dependencies.architectury_api = document.getElementById("architectury-api-input").checked;
+    state.dependencies.architectury_api = document.getElementById("architectury-api-input").checked && isArchitecturyApiAvailable();
 }
 
 function showError(error) {
@@ -148,9 +153,20 @@ function isForgeAvailable() {
     return supports_forge(version);
 }
 
+function isArchitecturyApiAvailable() {
+    const version = mcSelect.value;
+    if (document.getElementById("forge-loader-input").checked) {
+        return arch_api_supports_forge(version)
+    }
+    else {
+        return true;
+    }
+}
+
 function refreshAvailablePlatforms() {
     refreshForgeLikePlatform(isNeoForgeAvailable(), "neoforge");
     refreshForgeLikePlatform(isForgeAvailable(), "forge");
+    refreshArchitecturySupport()
 }
 
 function refreshForgeLikePlatform(available, id) {
@@ -164,6 +180,16 @@ function refreshForgeLikePlatform(available, id) {
         multiplatformInput.checked = true;
         projectInput.checked = false;
         refreshDisplayedProjectType();
+    }
+}
+
+function refreshArchitecturySupport() {
+    console.log(isArchitecturyApiAvailable())
+    if (!isArchitecturyApiAvailable()) {
+        document.getElementById("architectury-api-input").disabled = true
+    }
+    else {
+        document.getElementById("architectury-api-input").disabled = false
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -80,7 +80,8 @@ pub async fn generate(state: JsValue) {
 
 async fn generate_inner(state: JsValue) -> Result<(), JsValue> {
     let app: crate::app::GeneratorApp = serde_wasm_bindgen::from_value(state)?;
-    crate::app::generator::generate(&app).await
+    crate::app::generator::generate(&app)
+        .await
         .map_err(|err| JsValue::from(format!("{}", err)))
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -101,7 +101,7 @@ pub fn supports_forge(game_version: JsValue) -> Result<bool, JsValue> {
 pub fn arch_api_supports_forge(game_version: JsValue) -> Result<bool, JsValue> {
     let game_version: version_resolver::minecraft::MinecraftVersion = serde_wasm_bindgen::from_value(game_version)?;
     if game_version.forge_major_version().is_some() {
-        Ok(game_version.forge_major_version().expect("No forge version available!").parse::<i32>().unwrap() < 50)
+        Ok(game_version.forge_major_version().unwrap().parse::<i32>().unwrap() < 50)
     }
     else {
         Ok(false)

--- a/src/web.rs
+++ b/src/web.rs
@@ -81,7 +81,7 @@ pub async fn generate(state: JsValue) {
 async fn generate_inner(state: JsValue) -> Result<(), JsValue> {
     let app: crate::app::GeneratorApp = serde_wasm_bindgen::from_value(state)?;
     crate::app::generator::generate(&app)
-        .await
+            .await
         .map_err(|err| JsValue::from(format!("{}", err)))
 }
 
@@ -95,4 +95,15 @@ pub fn supports_neoforge(game_version: JsValue) -> Result<bool, JsValue> {
 pub fn supports_forge(game_version: JsValue) -> Result<bool, JsValue> {
     let game_version: version_resolver::minecraft::MinecraftVersion = serde_wasm_bindgen::from_value(game_version)?;
     Ok(game_version.forge_major_version().is_some())
+}
+
+#[wasm_bindgen]
+pub fn arch_api_supports_forge(game_version: JsValue) -> Result<bool, JsValue> {
+    let game_version: version_resolver::minecraft::MinecraftVersion = serde_wasm_bindgen::from_value(game_version)?;
+    if game_version.forge_major_version().is_some() {
+        Ok(game_version.forge_major_version().expect("No forge version available!").parse::<i32>().unwrap() < 50)
+    }
+    else {
+        Ok(false)
+    }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -80,8 +80,7 @@ pub async fn generate(state: JsValue) {
 
 async fn generate_inner(state: JsValue) -> Result<(), JsValue> {
     let app: crate::app::GeneratorApp = serde_wasm_bindgen::from_value(state)?;
-    crate::app::generator::generate(&app)
-            .await
+    crate::app::generator::generate(&app).await
         .map_err(|err| JsValue::from(format!("{}", err)))
 }
 
@@ -102,8 +101,7 @@ pub fn arch_api_supports_forge(game_version: JsValue) -> Result<bool, JsValue> {
     let game_version: version_resolver::minecraft::MinecraftVersion = serde_wasm_bindgen::from_value(game_version)?;
     if game_version.forge_major_version().is_some() {
         Ok(game_version.forge_major_version().unwrap().parse::<i32>().unwrap() < 50)
-    }
-    else {
+    } else {
         Ok(false)
     }
 }


### PR DESCRIPTION
This is a PR to improve #19 by adding support for disabling Architectury API on versions of LexForge where Architectury API is not available.