### PR TITLE
Ensure at least one loader is checked

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -174,6 +174,10 @@ function refreshFabricLikeCheckbox() {
     fabricLikeInput.disabled = !hasFabricLike;
 }
 
+function isLoaderChecked() {
+    return document.getElementById("fabric-loader-input").checked || document.getElementById("forge-loader-input").checked || document.getElementById("neoforge-loader-input").checked || document.getElementById("quilt-loader-input").checked
+}
+
 document.getElementById("generate-button").onclick = async () => {
     updateState();
 
@@ -186,6 +190,9 @@ document.getElementById("generate-button").onclick = async () => {
     } else if (state.package_name === "") {
         showError("Package name is empty");
         return;
+    } else if (!isLoaderChecked()) {
+        showError("You need to choose at least one subproject first!")
+        return
     }
 
     clearError();


### PR DESCRIPTION
Rebased version of #24 to no longer include the already merged commits from #23. 

I've seen multiple accounts of people using this generator and not realizing they need to check the boxes for the loaders they want to build for, so this PR adds in a simple check to see if any of the boxes are ticked.

Without selecting any loaders, Architectury will fail to build anyway - see https://github.com/architectury/architectury-api/issues/582 and in [Discord](https://discord.com/channels/792699517631594506/1299148417586692147/1299148417586692147).