### PR TITLE
Move Shadow Plugin from com.github.johnrengelman to com.gradleup

### DIFF
--- a/src/templates/fabric/build.gradle
+++ b/src/templates/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 architectury {

--- a/src/templates/forge/build.gradle
+++ b/src/templates/forge/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 loom {

--- a/src/templates/multiplatform/build.gradle
+++ b/src/templates/multiplatform/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'dev.architectury.loom' version '%LOOM_VERSION%' apply false
     id 'architectury-plugin' version '%PLUGIN_VERSION%'
-    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.gradleup.shadow' version '8.3.5' apply false
 }
 
 architectury {

--- a/src/templates/multiplatform/build.gradle
+++ b/src/templates/multiplatform/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'dev.architectury.loom' version '%LOOM_VERSION%' apply false
     id 'architectury-plugin' version '%PLUGIN_VERSION%'
-    id 'com.gradleup.shadow' version '8.3.5' apply false
+    id 'com.gradleup.shadow' version '8.3.6' apply false
 }
 
 architectury {

--- a/src/templates/neoforge/build.gradle
+++ b/src/templates/neoforge/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 architectury {

--- a/src/templates/quilt/build.gradle
+++ b/src/templates/quilt/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'com.gradleup.shadow'
 }
 
 repositories {


### PR DESCRIPTION
The old shadow plugin has been abandoned/moved to https://github.com/GradleUp/shadow, this updates the plugin to latest and changes everything over for to the new version