### PR TITLE
Only show subproject warning if multiplatform is selected

### DIFF
--- a/res/script.js
+++ b/res/script.js
@@ -190,7 +190,7 @@ document.getElementById("generate-button").onclick = async () => {
     } else if (state.package_name === "") {
         showError("Package name is empty");
         return;
-    } else if (!isLoaderChecked()) {
+    } else if ((!isLoaderChecked()) && (multiplatformInput.checked == true)) {
         showError("You need to choose at least one subproject first!")
         return
     }


### PR DESCRIPTION
The current implementation of the subproject warning I added shows the warning even if multiplatform isn't selected. This prevents NeoForge and Forge projects from being created unless a multiplatform box is checked. 